### PR TITLE
feat(customDelimiter): adds functionality to provide custom delimiters for number separation

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -3,7 +3,21 @@ export class StringCalculator {
     if (numbers === '') {
       return 0;
     }
-    const numArray = numbers.split(',').map((num) => parseInt(num));
+
+    const delimiters = new Array<string>(',', '\n');
+    const customDelimiterMatch = numbers.match(/^\/\/(.+)\n/);
+    let numbersWithoutCustomDelimiters = numbers;
+    if (customDelimiterMatch) {
+      delimiters.push(customDelimiterMatch[1]);
+      numbersWithoutCustomDelimiters = numbers.slice(
+        customDelimiterMatch[0].length,
+      );
+    }
+    const delimiterRegex = new RegExp(`[${delimiters.join('')}]`);
+    const numArray = numbersWithoutCustomDelimiters
+      .split(delimiterRegex)
+      .map((num) => parseInt(num));
+
     return numArray.reduce((sum, num) => sum + num);
   }
 }

--- a/tests/add.test.ts
+++ b/tests/add.test.ts
@@ -32,6 +32,7 @@ describe('String Calculator', () => {
   test('Should handle custom delimiters', () => {
     const calculator = new StringCalculator();
     expect(calculator.add('//;\n1;2')).toBe(3);
+    expect(calculator.add('//;\n1;2')).toBe(3);
   });
 
   test('Should throw an error for negative numbers', () => {


### PR DESCRIPTION
Explanation
To Support different delimiters:

To change the delimiter, the beginning of the string will contain a separate line that looks like this: "//[delimiter]\n[numbers…]". For example, "//;\n1;2" where the delimiter is ";" should return 3.