### PR TITLE
feat(multiple-repeating-delimiters): adds functionality to handle multiple delimiters

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -4,22 +4,32 @@ export class StringCalculator {
       return 0;
     }
 
-    const delimiters = new Array<string>(',', '\n');
+    const delimiters = [',', '\n'];
     const customDelimiterMatch = numbers.match(/^\/\/(.+)\n/);
     let numbersWithoutCustomDelimiters = numbers;
+
     if (customDelimiterMatch) {
-      delimiters.push(customDelimiterMatch[1]);
+      const customDelimiter = customDelimiterMatch[1];
+      if (customDelimiter.startsWith('[') && customDelimiter.endsWith(']')) {
+        const multipleDelimiters = customDelimiter
+          .slice(1, -1)
+          .split('][')
+          .map(this.escapeRegex);
+        delimiters.push(...multipleDelimiters);
+      } else {
+        delimiters.push(this.escapeRegex(customDelimiter));
+      }
       numbersWithoutCustomDelimiters = numbers.slice(
         customDelimiterMatch[0].length,
       );
     }
 
-    const delimiterRegex = new RegExp(`[${delimiters.join('')}]`);
-    const negativeNumbers = new Array<number>();
+    const delimiterRegex = new RegExp(delimiters.join('|'));
+    const negativeNumbers: number[] = [];
     const numArray = numbersWithoutCustomDelimiters
       .split(delimiterRegex)
       .map((num) => {
-        const parsedNum = parseInt(num);
+        const parsedNum = parseInt(num, 10);
         if (parsedNum < 0) {
           negativeNumbers.push(parsedNum);
         }
@@ -32,6 +42,11 @@ export class StringCalculator {
       );
     }
 
-    return numArray.reduce((sum, num) => sum + num);
+    return numArray.reduce((sum, num) => sum + num, 0);
+  }
+
+  private escapeRegex(delimiter: string): string {
+    // Src - https://stackoverflow.com/questions/3561493/is-there-a-regexp-escape-function-in-javascript/63838890#63838890
+    return delimiter.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
 }

--- a/tests/add.test.ts
+++ b/tests/add.test.ts
@@ -32,7 +32,8 @@ describe('String Calculator Milestone 1', () => {
   test('Should handle custom delimiters', () => {
     const calculator = new StringCalculator();
     expect(calculator.add('//;\n1;2')).toBe(3);
-    expect(calculator.add('//;\n1;2')).toBe(3);
+    expect(calculator.add('//&\n1&2')).toBe(3);
+    expect(calculator.add('//-\n1-2')).toBe(3);
   });
 
   test('Should throw an error for negative numbers', () => {
@@ -56,10 +57,19 @@ describe('String Calculator Milestone 2', () => {
   test('Should be able to handle delimiters of any length', () => {
     const calculator = new StringCalculator();
     expect(calculator.add('//[***]\n1***4***3')).toBe(8);
+    expect(calculator.add('//[---]\n1---4---3')).toBe(8);
   });
 
   test('Should allow multiple delimiters', () => {
     const calculator = new StringCalculator();
     expect(calculator.add('//[*][%]\n1*2%6')).toBe(9);
+    expect(calculator.add('//[*][%]\n1*2%6')).toBe(9);
+  });
+  test('Should handle multiple delimiters longer than one char', () => {
+    const calculator = new StringCalculator();
+    expect(calculator.add('//[**][%%]\n1**2%%6')).toBe(9);
+    expect(calculator.add('//[**]\n1**2**3')).toBe(6);
+    expect(calculator.add('//[..][%%]\n1..2%%11')).toBe(14);
+    expect(calculator.add('//[..][%%]\n1..2%%1999')).toBe(2002);
   });
 });

--- a/tests/add.test.ts
+++ b/tests/add.test.ts
@@ -1,6 +1,6 @@
 import { StringCalculator } from '../src/add';
 
-describe('String Calculator', () => {
+describe('String Calculator Milestone 1', () => {
   test('Should return Zero(0) for empty string input', () => {
     const calculator = new StringCalculator();
     const result = calculator.add('');
@@ -49,5 +49,17 @@ describe('String Calculator', () => {
     expect(() => calculator.add('-1,-2,3')).toThrow(
       'Negative numbers are not allowed: -1, -2',
     );
+  });
+});
+
+describe('String Calculator Milestone 2', () => {
+  test('Should be able to handle delimiters of any length', () => {
+    const calculator = new StringCalculator();
+    expect(calculator.add('//[***]\n1***4***3')).toBe(8);
+  });
+
+  test('Should allow multiple delimiters', () => {
+    const calculator = new StringCalculator();
+    expect(calculator.add('//[*][%]\n1*2%6')).toBe(9);
   });
 });


### PR DESCRIPTION
# Explanation

1. Delimiters can be of any length with the following format: “//[delimiter]\n” for example: “//[***]\n1***2***3” should return 6
2. Allow multiple delimiters like this: “//[delim1][delim2]\n” for example “//[*][%]\n1*2%3” should return 6.
3. make sure you can also handle multiple delimiters with length longer than one char